### PR TITLE
feat(pusher): add dual-path channel auth for host and guest

### DIFF
--- a/app/config/packages/doctrine.yaml
+++ b/app/config/packages/doctrine.yaml
@@ -4,7 +4,7 @@ doctrine:
 
         # IMPORTANT: You MUST configure your server version,
         # either here or in the DATABASE_URL env var (see .env file)
-        #server_version: '16'
+        server_version: '16'
 
         profiling_collect_backtrace: '%kernel.debug%'
     orm:

--- a/app/config/packages/security.yaml
+++ b/app/config/packages/security.yaml
@@ -43,6 +43,7 @@ security:
         - { path: ^/api/game-sessions/code/, roles: PUBLIC_ACCESS }
         - { path: ^/api/game-sessions/[0-9]+/guests, roles: PUBLIC_ACCESS }
         - { path: ^/api/game-sessions/[0-9]+/answer$, roles: PUBLIC_ACCESS }
+        - { path: ^/api/pusher/auth$, roles: PUBLIC_ACCESS }
         - { path: ^/api, roles: IS_AUTHENTICATED_FULLY }
 
 when@test:

--- a/app/src/Controller/PusherAuthController.php
+++ b/app/src/Controller/PusherAuthController.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace App\Controller;
+
+use App\Entity\User;
+use App\Repository\GameSessionGuestRepository;
+use App\Repository\GameSessionRepository;
+use App\Service\PusherPublisher;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\CurrentUser;
+
+#[Route('/api/pusher')]
+class PusherAuthController extends AbstractController
+{
+    public function __construct(
+        private readonly PusherPublisher $publisher,
+        private readonly GameSessionRepository $sessionRepository,
+        private readonly GameSessionGuestRepository $sessionGuestRepository,
+    ) {}
+
+    #[Route('/auth', name: 'api_pusher_auth', methods: ['POST'])]
+    public function auth(Request $request, #[CurrentUser] ?User $user): Response
+    {
+        $socketId    = $request->request->get('socket_id');
+        $channelName = $request->request->get('channel_name');
+
+        if (!$socketId || !$channelName) {
+            return new Response(
+                json_encode(['message' => 'socket_id and channel_name are required']),
+                Response::HTTP_BAD_REQUEST,
+                ['Content-Type' => 'application/json']
+            );
+        }
+
+        // Host path: authenticated via JWT
+        if ($user) {
+            $auth = $this->publisher->authenticate($socketId, $channelName);
+            return new Response($auth, Response::HTTP_OK, ['Content-Type' => 'application/json']);
+        }
+
+        // Guest path: validate guest_session_id against the session in the channel name
+        $guestSessionId = $request->request->get('guest_session_id');
+
+        if (!$guestSessionId || !preg_match('/^private-game-session-(\d+)$/', $channelName, $matches)) {
+            return new Response(
+                json_encode(['message' => 'Unauthorized']),
+                Response::HTTP_UNAUTHORIZED,
+                ['Content-Type' => 'application/json']
+            );
+        }
+
+        $sessionId = (int) $matches[1];
+        $session   = $this->sessionRepository->find($sessionId);
+
+        if (!$session) {
+            return new Response(
+                json_encode(['message' => 'Session not found']),
+                Response::HTTP_NOT_FOUND,
+                ['Content-Type' => 'application/json']
+            );
+        }
+
+        $sessionGuest = $this->sessionGuestRepository->findOneBySessionAndId($session, (int) $guestSessionId);
+
+        if (!$sessionGuest) {
+            return new Response(
+                json_encode(['message' => 'Unauthorized']),
+                Response::HTTP_UNAUTHORIZED,
+                ['Content-Type' => 'application/json']
+            );
+        }
+
+        $auth = $this->publisher->authenticate($socketId, $channelName);
+        return new Response($auth, Response::HTTP_OK, ['Content-Type' => 'application/json']);
+    }
+}

--- a/app/src/Service/PusherPublisher.php
+++ b/app/src/Service/PusherPublisher.php
@@ -46,6 +46,15 @@ class PusherPublisher
         $this->publish(sprintf('private-user-%d', $userId), $eventName, $payload);
     }
 
+    public function authenticate(string $socketId, string $channelName): string
+    {
+        if (!$this->client) {
+            throw new \RuntimeException('Pusher is not enabled or not configured.');
+        }
+
+        return $this->client->socketAuth($channelName, $socketId);
+    }
+
     private function publish(string $channel, string $eventName, array $payload): void
     {
         if (!$this->client) {


### PR DESCRIPTION
Create PusherAuthController with PUBLIC_ACCESS route that authenticates hosts via JWT and guests via guest_session_id validated against the session encoded in the channel name. Add PusherPublisher::authenticate() and fix doctrine server_version to resolve InvalidPlatformVersion error.