### PR TITLE
fix(guest): correct method call from getNickname() to getNickName()

### DIFF
--- a/app/src/Controller/GuestController.php
+++ b/app/src/Controller/GuestController.php
@@ -44,7 +44,7 @@ class GuestController extends AbstractController
 
         return $this->json([
             'id' => $newGuest->getId(),
-            'nickname' => $newGuest->getNickname(),
+            'nickname' => $newGuest->getNickName(),
             'avatar' => [
                 'id' => $newGuest->getAvatar()->getId(),
                 'url' => $baseUrl . '/' .$newGuest->getAvatar()->getPath(),


### PR DESCRIPTION
Guest entity only exposes getNickName() — calling the lowercase variant caused a PHP fatal error whenever a guest completed profile creation.